### PR TITLE
fix swizzle for newer pyobjc.

### DIFF
--- a/pytest_osxnotify/__init__.py
+++ b/pytest_osxnotify/__init__.py
@@ -42,7 +42,7 @@ def pytest_terminal_summary(terminalreporter):
 
 
 def swizzle(cls, SEL, func):
-    old_IMP = cls.instanceMethodForSelector_(SEL)
+    old_IMP = getattr(cls, SEL)
     def wrapper(self, *args, **kwargs):
         return func(self, old_IMP, *args, **kwargs)
     new_IMP = objc.selector(wrapper, selector=old_IMP.selector,


### PR DESCRIPTION
the `swizzle` function fails for me on OSX 10.10 with:

```
  File "/Users/rygwdn/.virtualenvs/aioTV/lib/python2.7/site-packages/pytest_osxnotify/__init__.py", line 22, in pytest_sessionstart
    notify('py.test', 'Running tests...')
  File "/Users/rygwdn/.virtualenvs/aioTV/lib/python2.7/site-packages/pytest_osxnotify/__init__.py", line 59, in notify
    swizzled_bundleIdentifier)
  File "/Users/rygwdn/.virtualenvs/aioTV/lib/python2.7/site-packages/pytest_osxnotify/__init__.py", line 44, in swizzle
    old_IMP = cls.instanceMethodForSelector_(SEL)
AttributeError: No selector bundleIdentifier
```

using `getattr` instead of `instanceMethodForSelector_` seems to fix the issue for me.
